### PR TITLE
関数名の変更

### DIFF
--- a/server/internal/handler/stamp.go
+++ b/server/internal/handler/stamp.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (h *Handler) getStamps(c echo.Context) error {
-	stamps, err := h.repo.GetStamps(c.Request().Context())
+	stamps, err := h.repo.GetStampDetails(c.Request().Context())
 	if err != nil{
 		return echo.NewHTTPError(http.StatusInternalServerError).SetInternal(err)
 	}


### PR DESCRIPTION
getSummaryとstamp.goを両方マージした結果エラーが起きていたので解消した